### PR TITLE
Update version to 1.4.8

### DIFF
--- a/rpcm/__about__.py
+++ b/rpcm/__about__.py
@@ -1,6 +1,6 @@
 __title__ = "rpcm"
 __description__ = "Rational Polynomial Camera Model for optical satellite images."
 __url__ = 'https://github.com/centreborelli/rpcm'
-__version__ = "1.4.7"
+__version__ = "1.4.8"
 __author__ = "Carlo de Franchis"
 __author_email__ = 'carlo.de-franchis@ens-paris-saclay.fr'


### PR DESCRIPTION
A few months ago support for Pleiades Neo was added in this PR: https://github.com/centreborelli/rpcm/pull/16 

But a new version needs to be released in order to use it in s2p (on `pypi` aswell or we have to install directly from the repo).