### PR TITLE
Remove srtm4 dependency

### DIFF
--- a/rpcm/__about__.py
+++ b/rpcm/__about__.py
@@ -1,6 +1,6 @@
 __title__ = "rpcm"
 __description__ = "Rational Polynomial Camera Model for optical satellite images."
 __url__ = 'https://github.com/centreborelli/rpcm'
-__version__ = "1.4.7"
+__version__ = "1.4.8"
 __author__ = "Carlo de Franchis"
 __author_email__ = 'carlo.de-franchis@ens-paris-saclay.fr'

--- a/rpcm/__init__.py
+++ b/rpcm/__init__.py
@@ -5,10 +5,10 @@ import geojson
 import numpy as np
 import rasterio
 import rasterio.warp
-import srtm4
 
 from rpcm import rpc_model
 from rpcm import utils
+from rpcm.dem import get_copernicus_elevation
 from rpcm.rpc_model import RPCModel
 from rpcm.rpc_model import rpc_from_geotiff
 from rpcm.rpc_model import rpc_from_rpc_file
@@ -54,7 +54,7 @@ def projection(img_path, lon, lat, z=None, crop_path=None, svg_path=None,
     """
     rpc = rpc_from_geotiff(img_path)
     if z is None:
-        z = srtm4.srtm4(lon, lat)
+        z = get_copernicus_elevation(lon, lat)
 
     x, y = rpc.projection(lon, lat, z)
 
@@ -126,7 +126,7 @@ def crop(output_crop_path, input_geotiff_path, aoi, z=None):
     """
     if z is None:  # read z from srtm
         lons, lats = np.asarray(aoi['coordinates']).squeeze().T
-        z = srtm4.srtm4(np.mean(lons[:-1]), np.mean(lats[:-1]))
+        z = get_copernicus_elevation(np.mean(lons[:-1]), np.mean(lats[:-1]))
 
     # do the crop
     crop, x, y = utils.crop_aoi(input_geotiff_path, aoi, z)
@@ -165,7 +165,7 @@ def image_footprint(geotiff_path, z=None, verbose=False):
     if rpc_dict:
         rpc = rpc_model.RPCModel(rpc_dict)
         if z is None:
-            z = srtm4.srtm4(rpc.lon_offset, rpc.lat_offset)
+            z = get_copernicus_elevation(rpc.lon_offset, rpc.lat_offset)
             if np.isnan(z):
                 warnings.warn("no SRTM altitude available, using RPC alt_offset",
                               category=NoSRTMWarning)
@@ -215,7 +215,7 @@ def angle_between_views(geotiff_path_1, geotiff_path_2, lon=None, lat=None,
     if lat is None:
         lat = rpc1.lat_offset
     if z is None:
-        z = srtm4.srtm4(lon, lat)
+        z = get_copernicus_elevation(lon, lat)
 
     a = utils.viewing_direction(*rpc1.incidence_angles(lon, lat, z))
     b = utils.viewing_direction(*rpc2.incidence_angles(lon, lat, z))

--- a/rpcm/dem.py
+++ b/rpcm/dem.py
@@ -1,0 +1,9 @@
+import rasterio as rio
+
+GCS_COPERNICUS_DEM_VRT = "gs://overstory-dtms/CopernicusDem30m/copernicus_dem/dem.vrt"
+
+def get_copernicus_elevation(lon: float, lat: float):
+    with rio.open(GCS_COPERNICUS_DEM_VRT) as src:
+        assert src.crs == "EPSG:4326"
+        elevation = list(src.sample([(lon, lat)]))[0]
+    return elevation

--- a/rpcm/rpc_file_readers.py
+++ b/rpcm/rpc_file_readers.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2015-19, Carlo de Franchis <carlo.de-franchis@cmla.ens-cachan.fr>
 # Copyright (C) 2015-19, Gabriele Facciolo <facciolo@cmla.ens-cachan.fr>
 # Copyright (C) 2015-19, Enric Meinhardt <enric.meinhardt@cmla.ens-cachan.fr>
-
-
 from xml.etree import ElementTree
 
 
@@ -11,99 +9,77 @@ def read_rpc_file(rpc_file):
     Read RPC from a file deciding the format from the extension of the filename.
       xml          : spot6, pleiades, worldview
       txt (others) : ikonos
-
     Args:
         rpc_file: RPC sidecar file path
-
     Returns:
         dictionary read from the RPC file, or an empty dict if fail
-
     """
-
     with open(rpc_file) as f:
         rpc_content = f.read()
-
-    if rpc_file.lower().endswith('xml'):
+    if rpc_file.lower().endswith("xml"):
         try:
             rpc = read_rpc_xml(rpc_content)
         except NotImplementedError:
-            raise NotImplementedError('XML file {} not supported'.format(rpc_file))
+            raise NotImplementedError("XML file {} not supported".format(rpc_file))
     else:
         # we assume that non xml rpc files follow the ikonos convention
         rpc = read_rpc_ikonos(rpc_content)
-
     return rpc
 
 
 def read_rpc_ikonos(rpc_content):
     """
     Read RPC file assuming the ikonos format
-
     Args:
         rpc_content: content of RPC sidecar file path read as a string
-
     Returns:
         dictionary read from the RPC file
-
     """
     import re
-
-    lines = rpc_content.split('\n')
-
+    lines = rpc_content.split("\n")
     d = {}
     for l in lines:
         ll = l.split()
         if len(ll) > 1:
             k = re.sub(r"[^a-zA-Z0-9_]","",ll[0])
             d[k] = ll[1]
-
     def parse_coeff(dic, prefix, indices):
         """ helper function"""
-        return ' '.join([dic["%s_%s" % (prefix, str(x))] for x in indices])
-
-    d['SAMP_NUM_COEFF']  = parse_coeff(d, "SAMP_NUM_COEFF", range(1, 21))
-    d['SAMP_DEN_COEFF']  = parse_coeff(d, "SAMP_DEN_COEFF", range(1, 21))
-    d['LINE_NUM_COEFF']  = parse_coeff(d, "LINE_NUM_COEFF", range(1, 21))
-    d['LINE_DEN_COEFF']  = parse_coeff(d, "LINE_DEN_COEFF", range(1, 21))
+        return " ".join([dic["%s_%s" % (prefix, str(x))] for x in indices])
+    d["SAMP_NUM_COEFF"]  = parse_coeff(d, "SAMP_NUM_COEFF", range(1, 21))
+    d["SAMP_DEN_COEFF"]  = parse_coeff(d, "SAMP_DEN_COEFF", range(1, 21))
+    d["LINE_NUM_COEFF"]  = parse_coeff(d, "LINE_NUM_COEFF", range(1, 21))
+    d["LINE_DEN_COEFF"]  = parse_coeff(d, "LINE_DEN_COEFF", range(1, 21))
 
     return d
 
 
-
 def read_rpc_xml(rpc_content):
     """
-    Read RPC file assuming the XML format and determine whether it's a pleiades, spot-6 or worldview image
-
+    Read RPC file assuming the XML format and determine whether it’s a pleiades, spot-6 or worldview image
     Args:
         rpc_content: content of RPC sidecar file path read as a string (XML format)
-
     Returns:
         dictionary read from the RPC file
-
     Raises:
         NotImplementedError: if the file format is not handled (the expected keys are not found)
-
     """
-
     # parse the xml file content
     tree = ElementTree.fromstring(rpc_content)
-
-    # determine wether it's a pleiades, spot-6 or worldview image
-    a = tree.find('Metadata_Identification/METADATA_PROFILE') # PHR_SENSOR
-    b = tree.find('IMD/IMAGE/SATID') # WorldView
+    # determine wether it"s a pleiades, spot-6 or worldview image
+    a = tree.find("Metadata_Identification/METADATA_PROFILE") # PHR_SENSOR
+    b = tree.find("IMD/IMAGE/SATID") # WorldView
     parsed_rpc = None
     if a is not None:
-        if a.text in ['PHR_SENSOR', 'S6_SENSOR', 'S7_SENSOR']:
+        if a.text in ["PHR_SENSOR", "S6_SENSOR", "S7_SENSOR"]:
             parsed_rpc = read_rpc_xml_pleiades(tree)
-        elif a.text in ['PNEO_SENSOR']:
+        elif a.text in ["PNEO_SENSOR"]:
             parsed_rpc = read_rpc_xml_pleiades_neo(tree)
     elif b is not None:
-        if b.text == 'WV02' or b.text == 'WV01' or b.text == 'WV03':
+        if b.text == "WV02" or b.text == "WV01" or b.text == "WV03":
             parsed_rpc = read_rpc_xml_worldview(tree)
-
     if not parsed_rpc:
         raise NotImplementedError()
-
     return parsed_rpc
 
 
@@ -111,66 +87,64 @@ def read_rpc_xml_pleiades(tree):
     """
     Read RPC fields from a parsed XML tree assuming the pleiades, spot-6 XML format
     Also reads the inverse model parameters
-
     Args:
         tree: parsed XML tree
-
     Returns:
         dictionary read from the RPC file, or empty dict in case of failure
-
     """
     m = {}
-
+    
     def parse_coeff(element, prefix, indices):
-        """ helper function"""
-        return ' '.join([element.find("%s_%s" % (prefix, str(x))).text for x in indices])
-
+        """
+        helper function    
+        """
+        return " ".join([element.find("%s_%s" % (prefix, str(x))).text for x in indices])
+    
     # direct model (LOCALIZATION)
-    d = tree.find('Rational_Function_Model/Global_RFM/Direct_Model')
-    m['LON_NUM_COEFF'] = parse_coeff(d, "SAMP_NUM_COEFF", range(1, 21))
-    m['LON_DEN_COEFF'] = parse_coeff(d, "SAMP_DEN_COEFF", range(1, 21))
-    m['LAT_NUM_COEFF'] = parse_coeff(d, "LINE_NUM_COEFF", range(1, 21))
-    m['LAT_DEN_COEFF'] = parse_coeff(d, "LINE_DEN_COEFF", range(1, 21))
-    #m['ERR_BIAS']       = parse_coeff(d, "ERR_BIAS", ['X', 'Y'])
-
-
+    d = tree.find("Rational_Function_Model/Global_RFM/Direct_Model")
+    m["LON_NUM_COEFF"] = parse_coeff(d, "SAMP_NUM_COEFF", range(1, 21))
+    m["LON_DEN_COEFF"] = parse_coeff(d, "SAMP_DEN_COEFF", range(1, 21))
+    m["LAT_NUM_COEFF"] = parse_coeff(d, "LINE_NUM_COEFF", range(1, 21))
+    m["LAT_DEN_COEFF"] = parse_coeff(d, "LINE_DEN_COEFF", range(1, 21))
+    #m["ERR_BIAS"]       = parse_coeff(d, "ERR_BIAS", ["X", "Y"])
     ## inverse model (PROJECTION)
-    i = tree.find('Rational_Function_Model/Global_RFM/Inverse_Model')
-    m['SAMP_NUM_COEFF']  = parse_coeff(i, "SAMP_NUM_COEFF", range(1, 21))
-    m['SAMP_DEN_COEFF']  = parse_coeff(i, "SAMP_DEN_COEFF", range(1, 21))
-    m['LINE_NUM_COEFF']  = parse_coeff(i, "LINE_NUM_COEFF", range(1, 21))
-    m['LINE_DEN_COEFF']  = parse_coeff(i, "LINE_DEN_COEFF", range(1, 21))
-    m['ERR_BIAS']        = parse_coeff(i, "ERR_BIAS", ['ROW', 'COL'])
-
+    i = tree.find("Rational_Function_Model/Global_RFM/Inverse_Model")
+    m["SAMP_NUM_COEFF"]  = parse_coeff(i, "SAMP_NUM_COEFF", range(1, 21))
+    m["SAMP_DEN_COEFF"]  = parse_coeff(i, "SAMP_DEN_COEFF", range(1, 21))
+    m["LINE_NUM_COEFF"]  = parse_coeff(i, "LINE_NUM_COEFF", range(1, 21))
+    m["LINE_DEN_COEFF"]  = parse_coeff(i, "LINE_DEN_COEFF", range(1, 21))
+    m["ERR_BIAS"]        = parse_coeff(i, "ERR_BIAS", ["ROW", "COL"])
     # validity domains
-    v = tree.find('Rational_Function_Model/Global_RFM/RFM_Validity')
-    #vd = v.find('Direct_Model_Validity_Domain')
-    #m.firstRow = float(vd.find('FIRST_ROW').text)
-    #m.firstCol = float(vd.find('FIRST_COL').text)
-    #m.lastRow  = float(vd.find('LAST_ROW').text)
-    #m.lastCol  = float(vd.find('LAST_COL').text)
-
-    #vi = v.find('Inverse_Model_Validity_Domain')
-    #m.firstLon = float(vi.find('FIRST_LON').text)
-    #m.firstLat = float(vi.find('FIRST_LAT').text)
-    #m.lastLon  = float(vi.find('LAST_LON').text)
-    #m.lastLat  = float(vi.find('LAST_LAT').text)
-
+    v = tree.find("Rational_Function_Model/Global_RFM/RFM_Validity")
+    i = tree.find("Rational_Function_Model/Global_RFM/RFM_Validity/Inverse_Model_Validity_Domain")
+    #vd = v.find("Direct_Model_Validity_Domain")
+    #m.firstRow = float(vd.find("FIRST_ROW").text)
+    #m.firstCol = float(vd.find("FIRST_COL").text)
+    #m.lastRow  = float(vd.find("LAST_ROW").text)
+    #m.lastCol  = float(vd.find("LAST_COL").text)
+    #vi = v.find("Inverse_Model_Validity_Domain")
+    #m.firstLon = float(vi.find("FIRST_LON").text)
+    #m.firstLat = float(vi.find("FIRST_LAT").text)
+    #m.lastLon  = float(vi.find("LAST_LON").text)
+    #m.lastLat  = float(vi.find("LAST_LAT").text)
     # scale and offset
     # the -1 in line and column offsets is due to Pleiades RPC convention
     # that states that the top-left pixel of an image has coordinates
     # (1, 1)
-    m['LINE_OFF'    ] = float(v.find('LINE_OFF').text) - 1
-    m['SAMP_OFF'    ] = float(v.find('SAMP_OFF').text) - 1
-    m['LAT_OFF'     ] = float(v.find('LAT_OFF').text)
-    m['LONG_OFF'    ] = float(v.find('LONG_OFF').text)
-    m['HEIGHT_OFF'  ] = float(v.find('HEIGHT_OFF').text)
-    m['LINE_SCALE'  ] = float(v.find('LINE_SCALE').text)
-    m['SAMP_SCALE'  ] = float(v.find('SAMP_SCALE').text)
-    m['LAT_SCALE'   ] = float(v.find('LAT_SCALE').text)
-    m['LONG_SCALE'  ] = float(v.find('LONG_SCALE').text)
-    m['HEIGHT_SCALE'] = float(v.find('HEIGHT_SCALE').text)
-
+    m["LINE_OFF"    ] = float(v.find("LINE_OFF").text) - 1
+    m["SAMP_OFF"    ] = float(v.find("SAMP_OFF").text) - 1
+    m["LAT_OFF"     ] = float(v.find("LAT_OFF").text)
+    m["LONG_OFF"    ] = float(v.find("LONG_OFF").text)
+    m["HEIGHT_OFF"  ] = float(v.find("HEIGHT_OFF").text)
+    m["LINE_SCALE"  ] = float(v.find("LINE_SCALE").text)
+    m["SAMP_SCALE"  ] = float(v.find("SAMP_SCALE").text)
+    m["LAT_SCALE"   ] = float(v.find("LAT_SCALE").text)
+    m["LONG_SCALE"  ] = float(v.find("LONG_SCALE").text)
+    m["HEIGHT_SCALE"] = float(v.find("HEIGHT_SCALE").text)
+    m["FIRST_LON"] = float(i.find("FIRST_LON").text)
+    m["FIRST_LAT"] = float(i.find("FIRST_LAT").text)
+    m["LAST_LON"] = float(i.find("LAST_LON").text)
+    m["LAST_LAT"] = float(i.find("LAST_LAT").text)
     return m
 
 
@@ -184,101 +158,91 @@ def read_rpc_xml_pleiades_neo(tree):
         dictionary read from the RPC file, or empty dict in case of failure
     """
     m = {}
-
+    
     def parse_coeff(element, prefix, indices):
-        """ helper function"""
-        return ' '.join([element.find("%s_%s" % (prefix, str(x))).text for x in indices])
+        """
+        helper function
+        """
+        return " ".join([element.find("%s_%s" % (prefix, str(x))).text for x in indices])
 
+    
     # direct model (LOCALIZATION)
-    d = tree.find('Rational_Function_Model/Global_RFM/ImagetoGround_Values')
-    m['LON_NUM_COEFF'] = parse_coeff(d, "LON_NUM_COEFF", range(1, 21))
-    m['LON_DEN_COEFF'] = parse_coeff(d, "LON_DEN_COEFF", range(1, 21))
-    m['LAT_NUM_COEFF'] = parse_coeff(d, "LAT_NUM_COEFF", range(1, 21))
-    m['LAT_DEN_COEFF'] = parse_coeff(d, "LAT_DEN_COEFF", range(1, 21))
-    #m['ERR_BIAS']       = parse_coeff(d, "ERR_BIAS", ['X', 'Y'])
-
-
+    d = tree.find("Rational_Function_Model/Global_RFM/ImagetoGround_Values")
+    m["LON_NUM_COEFF"] = parse_coeff(d, "LON_NUM_COEFF", range(1, 21))
+    m["LON_DEN_COEFF"] = parse_coeff(d, "LON_DEN_COEFF", range(1, 21))
+    m["LAT_NUM_COEFF"] = parse_coeff(d, "LAT_NUM_COEFF", range(1, 21))
+    m["LAT_DEN_COEFF"] = parse_coeff(d, "LAT_DEN_COEFF", range(1, 21))
+    #m["ERR_BIAS"]       = parse_coeff(d, "ERR_BIAS", ["X", "Y"])
     ## inverse model (PROJECTION)
-    i = tree.find('Rational_Function_Model/Global_RFM/GroundtoImage_Values')
-    m['SAMP_NUM_COEFF']  = parse_coeff(i, "SAMP_NUM_COEFF", range(1, 21))
-    m['SAMP_DEN_COEFF']  = parse_coeff(i, "SAMP_DEN_COEFF", range(1, 21))
-    m['LINE_NUM_COEFF']  = parse_coeff(i, "LINE_NUM_COEFF", range(1, 21))
-    m['LINE_DEN_COEFF']  = parse_coeff(i, "LINE_DEN_COEFF", range(1, 21))
-    m['ERR_BIAS']        = parse_coeff(i, "ERR_BIAS", ['ROW', 'COL'])
-
+    i = tree.find("Rational_Function_Model/Global_RFM/GroundtoImage_Values")
+    m["SAMP_NUM_COEFF"]  = parse_coeff(i, "SAMP_NUM_COEFF", range(1, 21))
+    m["SAMP_DEN_COEFF"]  = parse_coeff(i, "SAMP_DEN_COEFF", range(1, 21))
+    m["LINE_NUM_COEFF"]  = parse_coeff(i, "LINE_NUM_COEFF", range(1, 21))
+    m["LINE_DEN_COEFF"]  = parse_coeff(i, "LINE_DEN_COEFF", range(1, 21))
+    m["ERR_BIAS"]        = parse_coeff(i, "ERR_BIAS", ["ROW", "COL"])
     # validity domains
-    v = tree.find('Rational_Function_Model/Global_RFM/RFM_Validity')
-    #vd = v.find('Direct_Model_Validity_Domain')
-    #m.firstRow = float(vd.find('FIRST_ROW').text)
-    #m.firstCol = float(vd.find('FIRST_COL').text)
-    #m.lastRow  = float(vd.find('LAST_ROW').text)
-    #m.lastCol  = float(vd.find('LAST_COL').text)
-
-    #vi = v.find('Inverse_Model_Validity_Domain')
-    #m.firstLon = float(vi.find('FIRST_LON').text)
-    #m.firstLat = float(vi.find('FIRST_LAT').text)
-    #m.lastLon  = float(vi.find('LAST_LON').text)
-    #m.lastLat  = float(vi.find('LAST_LAT').text)
-
+    v = tree.find("Rational_Function_Model/Global_RFM/RFM_Validity")
+    g = tree.find("Rational_Function_Model/Global_RFM/RFM_Validity/GroundtoImage_Validity_Domain")
+    #vd = v.find("Direct_Model_Validity_Domain")
+    #m.firstRow = float(vd.find("FIRST_ROW").text)
+    #m.firstCol = float(vd.find("FIRST_COL").text)
+    #m.lastRow  = float(vd.find("LAST_ROW").text)
+    #m.lastCol  = float(vd.find("LAST_COL").text)
+    #vi = v.find("Inverse_Model_Validity_Domain")
+    #m.firstLon = float(vi.find("FIRST_LON").text)
+    #m.firstLat = float(vi.find("FIRST_LAT").text)
+    #m.lastLon  = float(vi.find("LAST_LON").text)
+    #m.lastLat  = float(vi.find("LAST_LAT").text)
     # scale and offset
     # the -1 in line and column offsets is due to Pleiades RPC convention
     # that states that the top-left pixel of an image has coordinates
     # (1, 1)
-    m['LINE_OFF'    ] = float(v.find('LINE_OFF').text) - 1
-    m['SAMP_OFF'    ] = float(v.find('SAMP_OFF').text) - 1
-    m['LAT_OFF'     ] = float(v.find('LAT_OFF').text)
-    m['LONG_OFF'    ] = float(v.find('LONG_OFF').text)
-    m['HEIGHT_OFF'  ] = float(v.find('HEIGHT_OFF').text)
-    m['LINE_SCALE'  ] = float(v.find('LINE_SCALE').text)
-    m['SAMP_SCALE'  ] = float(v.find('SAMP_SCALE').text)
-    m['LAT_SCALE'   ] = float(v.find('LAT_SCALE').text)
-    m['LONG_SCALE'  ] = float(v.find('LONG_SCALE').text)
-    m['HEIGHT_SCALE'] = float(v.find('HEIGHT_SCALE').text)
-
+    m["LINE_OFF"    ] = float(v.find("LINE_OFF").text) - 1
+    m["SAMP_OFF"    ] = float(v.find("SAMP_OFF").text) - 1
+    m["LAT_OFF"     ] = float(v.find("LAT_OFF").text)
+    m["LONG_OFF"    ] = float(v.find("LONG_OFF").text)
+    m["HEIGHT_OFF"  ] = float(v.find("HEIGHT_OFF").text)
+    m["LINE_SCALE"  ] = float(v.find("LINE_SCALE").text)
+    m["SAMP_SCALE"  ] = float(v.find("SAMP_SCALE").text)
+    m["LAT_SCALE"   ] = float(v.find("LAT_SCALE").text)
+    m["LONG_SCALE"  ] = float(v.find("LONG_SCALE").text)
+    m["HEIGHT_SCALE"] = float(v.find("HEIGHT_SCALE").text)
+    m["FIRST_LON"] = float(g.find("FIRST_LON").text)
+    m["FIRST_LAT"] = float(g.find("FIRST_LAT").text)
+    m["LAST_LON"] = float(g.find("LAST_LON").text)
+    m["LAST_LAT"] = float(g.find("LAST_LAT").text)
     return m
 
 
 def read_rpc_xml_worldview(tree):
     """
     Read RPC fields from a parsed XML tree assuming the worldview XML format
-
     Args:
         tree: parsed XML tree
-
     Returns:
         dictionary read from the RPC file, or empty dict in case of failure
-
     """
     m = {}
-
     # inverse model (PROJECTION)
-    im = tree.find('RPB/IMAGE')
-    l = im.find('LINENUMCOEFList/LINENUMCOEF')
-    m['LINE_NUM_COEFF'] =  l.text
-    l = im.find('LINEDENCOEFList/LINEDENCOEF')
-    m['LINE_DEN_COEFF'] =  l.text
-    l = im.find('SAMPNUMCOEFList/SAMPNUMCOEF')
-    m['SAMP_NUM_COEFF'] =  l.text
-    l = im.find('SAMPDENCOEFList/SAMPDENCOEF')
-    m['SAMP_DEN_COEFF'] =  l.text
-    m['ERR_BIAS'] = float(im.find('ERRBIAS').text)
-
+    im = tree.find("RPB/IMAGE")
+    l = im.find("LINENUMCOEFList/LINENUMCOEF")
+    m["LINE_NUM_COEFF"] =  l.text
+    l = im.find("LINEDENCOEFList/LINEDENCOEF")
+    m["LINE_DEN_COEFF"] =  l.text
+    l = im.find("SAMPNUMCOEFList/SAMPNUMCOEF")
+    m["SAMP_NUM_COEFF"] =  l.text
+    l = im.find("SAMPDENCOEFList/SAMPDENCOEF")
+    m["SAMP_DEN_COEFF"] =  l.text
+    m["ERR_BIAS"] = float(im.find("ERRBIAS").text)
     # scale and offset
-    m['LINE_OFF'    ] = float(im.find('LINEOFFSET').text)
-    m['SAMP_OFF'    ] = float(im.find('SAMPOFFSET').text)
-    m['LAT_OFF'     ] = float(im.find('LATOFFSET').text)
-    m['LONG_OFF'    ] = float(im.find('LONGOFFSET').text)
-    m['HEIGHT_OFF'  ] = float(im.find('HEIGHTOFFSET').text)
-
-    m['LINE_SCALE'  ] = float(im.find('LINESCALE').text)
-    m['SAMP_SCALE'  ] = float(im.find('SAMPSCALE').text)
-    m['LAT_SCALE'   ] = float(im.find('LATSCALE').text)
-    m['LONG_SCALE'  ] = float(im.find('LONGSCALE').text)
-    m['HEIGHT_SCALE'] = float(im.find('HEIGHTSCALE').text)
-
-
-#    # image dimensions
-#    m.lastRow = int(tree.find('IMD/NUMROWS').text)
-#    m.lastCol = int(tree.find('IMD/NUMCOLUMNS').text)
-
+    m["LINE_OFF"    ] = float(im.find("LINEOFFSET").text)
+    m["SAMP_OFF"    ] = float(im.find("SAMPOFFSET").text)
+    m["LAT_OFF"     ] = float(im.find("LATOFFSET").text)
+    m["LONG_OFF"    ] = float(im.find("LONGOFFSET").text)
+    m["HEIGHT_OFF"  ] = float(im.find("HEIGHTOFFSET").text)
+    m["LINE_SCALE"  ] = float(im.find("LINESCALE").text)
+    m["SAMP_SCALE"  ] = float(im.find("SAMPSCALE").text)
+    m["LAT_SCALE"   ] = float(im.find("LATSCALE").text)
+    m["LONG_SCALE"  ] = float(im.find("LONGSCALE").text)
+    m["HEIGHT_SCALE"] = float(im.find("HEIGHTSCALE").text)
     return m

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ def readme():
 requirements = ['numpy',
                 'pyproj',
                 'geojson',
-                'rasterio[s3]>=1.2',
-                'srtm4>=1.0.2']
+                'rasterio[s3]>=1.2']
 
 extras_require = {'test': ['pytest']}
 


### PR DESCRIPTION
# Problem
`srtm4` is a python library that downloads srtm files locally and then reads them to extract elevation data at specific latitudes and longitudes. There are two problems with `srtm4`:
1. The large srtm tiles are downloaded at every data-ingestion pipeline run. This takes time and is inefficient.
2. The `srtm4` library [requires special treatment to run locally on MacOS and complicates local development](https://github.com/20treeAI/data-ingestion?tab=readme-ov-file#srtm4-install-error-on-macos).

# Solution

We already have a Copernicus DEM on GCS which dynamically builds up as new tiles are required. We could obtain elevation data by very quickly reading the elevation points from these cloud optimized geotifs.